### PR TITLE
Update invite regex to suppord discord.com

### DIFF
--- a/src/corebot/Commands.java
+++ b/src/corebot/Commands.java
@@ -37,7 +37,7 @@ public class Commands{
     private CommandHandler handler = new CommandHandler(prefix);
     private CommandHandler adminHandler = new CommandHandler(prefix);
     private String[] warningStrings = {"once", "twice", "thrice", "too many times"};
-    private Pattern invitePattern = Pattern.compile("(discord\\.gg/\\w|discordapp\\.com/invite/\\w)");
+    private Pattern invitePattern = Pattern.compile("(discord\\.gg/\\w|discordapp\\.com/invite/\\w|discord\\.com/invite/\\w)");
 
     Commands(){
         handler.register("help", "Displays all bot commands.", args -> {


### PR DESCRIPTION
discord.com/invite/blahblah works now because discord marketing team thought it was a good idea, this pr patches the outdated regex and blocks new invite links.