### PR TITLE
Attempt to fix unique pings ban action

### DIFF
--- a/src/corebot/Messages.java
+++ b/src/corebot/Messages.java
@@ -40,7 +40,7 @@ import static corebot.CoreBot.*;
 
 public class Messages extends ListenerAdapter{
     private static final String prefix = "!";
-    private static final int scamAutobanLimit = 4, pingSpamLimit = 12;
+    private static final int scamAutobanLimit = 4, pingSpamLimit = 24;
     private static final SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd");
     private static final String[] warningStrings = {"once", "twice", "thrice", "too many times"};
 
@@ -753,13 +753,12 @@ public class Messages extends ListenerAdapter{
             for(var ping : mentioned){
                 if(!ping.equals(data.lastPingId)){
                     data.lastPingId = ping;
+                    data.uniquePings++;
                     if(data.uniquePings >= pingSpamLimit){
                         Log.info("Autobanning @ for spamming @ pings in a row.", message.getAuthor().getName() + "#" + message.getAuthor().getId(), data.uniquePings);
                         alertsChannel.sendMessage(message.getAuthor().getAsMention() + " **has been auto-banned for pinging " + pingSpamLimit + " unique members in a row!**").queue();
                         message.getGuild().ban(message.getAuthor(), 1, "Banned for spamming member pings. If you believe this was in error, file an issue on the CoreBot Github (https://github.com/Anuken/CoreBot/issues) or contact a moderator.").queue();
                     }
-                }else{
-                    data.uniquePings = 0;
                 }
             }
 
@@ -911,6 +910,5 @@ public class Messages extends ListenerAdapter{
         String lastPingId;
         /** number of unique members pinged in a row */
         int uniquePings;
-
     }
 }


### PR DESCRIPTION
- Increment UserData.uniquePings when a ping is found
- Remove the branch resetting ping count on duplicate ping, as that could allow bypassing this check simply by pinging every user in sequence twice.
- Increase spam limit from 12 to 24 to hopefully reduce false positives (most recent spam flood had >40 pings per message, 24 should be a decent limit I believe)

Maybe it would be better to have a check for consecutive ping spam messages?